### PR TITLE
Button Height

### DIFF
--- a/src/main/kotlin/cc/woverflow/chatting/gui/components/SearchButton.kt
+++ b/src/main/kotlin/cc/woverflow/chatting/gui/components/SearchButton.kt
@@ -47,7 +47,7 @@ class SearchButton :
         69420,
         Minecraft.getMinecraft().fontRendererObj,
         UResolution.scaledWidth * 4 / 5 - 60,
-        UResolution.scaledHeight - 27,
+        UResolution.scaledHeight - 26,
         UResolution.scaledWidth / 5,
         12
     ) {


### PR DESCRIPTION
Moving the Screenshot Chat and Search buttons 1 pixel up to match the other distances