### PR TITLE
Button Height

### DIFF
--- a/src/main/kotlin/cc/woverflow/chatting/gui/components/ScreenshotButton.kt
+++ b/src/main/kotlin/cc/woverflow/chatting/gui/components/ScreenshotButton.kt
@@ -11,7 +11,7 @@ import net.minecraft.client.renderer.GlStateManager
 import net.minecraft.util.ResourceLocation
 
 class ScreenshotButton :
-    CleanButton(448318, { UResolution.scaledWidth - 28 }, { UResolution.scaledHeight - 27 }, 12, 12, "",
+    CleanButton(448318, { UResolution.scaledWidth - 28 }, { UResolution.scaledHeight - 26 }, 12, 12, "",
         { RenderType.NONE }) {
 
     override fun onMousePress() {


### PR DESCRIPTION
Moving the Screenshot Chat and Search buttons 1 pixel up to match the other distances